### PR TITLE
Shell recipes tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
 
 script:
   - cd station && pytest -v ; cd ..
-  - cd server && PYTHONTEST=. pytest -v ; cd..
+  - cd server && PYTHONTEST=. pytest -v ; cd ..
   - shellcheck ${SHELL_SCRIPTS} ${SHELLCHECK_OPTS}
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ python:
   - "3.7"
   - "3.8"
 
+env:
+  - SHELL_SCRIPTS  = "station/recipes/meteor-qpsk.sh"
+  - SHELL_SCRIPTS += "station/recipes/noaa-apt.sh"
+  - SHELLCHECK_OPTS = ""
+
 #services:
 #  - postgresql
 
@@ -19,6 +24,7 @@ install:
   - pip install -r station/requirements.txt
   - pip install -r server/requirements.txt
   - pip install pytest
+  - apt install shellcheck
 
 before_script:
   - psql -c 'create database satnogs;' -U postgres
@@ -30,6 +36,7 @@ before_script:
 script:
   - cd station && pytest -v && cd ..
   - cd server && PYTHONTEST=. pytest -v
+  - shellcheck ${SCRIPTS} ${SHELLCHECK_OPTS}
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_script:
   - mkdir -p ~/.config/satnogs-gut
 
 script:
-  - cd station && pytest -v && cd ..
-  - cd server && PYTHONTEST=. pytest -v
+  - cd station && pytest -v ; cd ..
+  - cd server && PYTHONTEST=. pytest -v ; cd..
   - shellcheck ${SHELL_SCRIPTS} ${SHELLCHECK_OPTS}
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
 script:
   - cd station && pytest -v && cd ..
   - cd server && PYTHONTEST=. pytest -v
-  - shellcheck ${SCRIPTS} ${SHELLCHECK_OPTS}
+  - shellcheck ${SHELL_SCRIPTS} ${SHELLCHECK_OPTS}
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ python:
   - "3.8"
 
 env:
-  - SHELL_SCRIPTS  = "station/recipes/meteor-qpsk.sh"
-  - SHELL_SCRIPTS += "station/recipes/noaa-apt.sh"
-  - SHELLCHECK_OPTS = ""
+  - SHELL_SCRIPTS="station/recipes/meteor-qpsk.sh station/recipes/noaa-apt.sh" SHELLCHECK_OPTS=""
 
 #services:
 #  - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ addons:
     packages:
     - postgresql-10
     - postgresql-client-10
+    - shellcheck
 
 install:
   - pip install -r station/requirements.txt
   - pip install -r server/requirements.txt
   - pip install pytest
-  - apt install shellcheck
 
 before_script:
   - psql -c 'create database satnogs;' -U postgres

--- a/station/recipes/meteor-qpsk.sh
+++ b/station/recipes/meteor-qpsk.sh
@@ -57,8 +57,6 @@ meteor_demod_name() {
 meteor_demod_name
 echo "METEOR DEMOD found: [$METEOR_DEMOD]"
 
-$METEOR_DEMOD
-
 # Record raw IQ data
 timeout "$RECEIVE_TIMEOUT" \
     rtl_fm -M raw -f "$FREQUENCY" -s 288k -g 48 -p 1 | \
@@ -93,7 +91,7 @@ echo "Decoded"
 convert "$PRODUCT_BITMAP_FILENAME" "$PRODUCT_FILENAME" || exit $?
 rm "$PRODUCT_BITMAP_FILENAME"
 echo "Converted"
-echo !! Product: "$PRODUCT_FILENAME"
+echo "!! Product: $PRODUCT_FILENAME"
 
 # Demodulator from: https://github.com/dbdexter-dev/meteor_demod
 # Decoder from: https://github.com/artlav/meteor_decoder

--- a/station/recipes/noaa-apt.sh
+++ b/station/recipes/noaa-apt.sh
@@ -13,6 +13,12 @@
 # where CATEGORY is label, tag, category of file and PATH is path to this file.
 # Caller is responsible for returned paths.
 
+if test "$#" -ne 3; then
+    echo "ERROR: Expected exactly 3 parameters: BASENAME FREQUENCY RECEIVE_TIMEOUT"
+    echo "ERROR: See comment in $0 for details."
+    exit 1
+fi
+
 BASENAME=$1
 FREQUENCY=$2
 RECEIVE_TIMEOUT=$3
@@ -21,17 +27,17 @@ SIGNAL_FILENAME=${BASENAME}_signal.wav
 PRODUCT_FILENAME=${BASENAME}_product.png
 
 # Record signal
-timeout $RECEIVE_TIMEOUT \
-	rtl_fm -d 0 -f $FREQUENCY -s 48000 -g 49.6 -p 1 -F 9 -A fast -E DC - | \
-	sox -t raw -b16 -es -r 48000 -c1 -V1 - $SIGNAL_FILENAME rate 11025
+timeout "$RECEIVE_TIMEOUT" \
+	rtl_fm -d 0 -f "$FREQUENCY" -s 48000 -g 49.6 -p 1 -F 9 -A fast -E DC - | \
+	sox -t raw -b16 -es -r 48000 -c1 -V1 - "$SIGNAL_FILENAME" rate 11025
 
 retVal=$?
 if [ $retVal -ne 0 ]; then
     exit $retVal
 fi
 
-echo !! Signal: $SIGNAL_FILENAME
+echo !! Signal: "$SIGNAL_FILENAME"
 
 # Decode signal
-noaa-apt -o $PRODUCT_FILENAME $SIGNAL_FILENAME || exit $?
-echo !! Product: $PRODUCT_FILENAME
+noaa-apt -o "$PRODUCT_FILENAME $SIGNAL_FILENAME" || exit $?
+echo !! Product: "$PRODUCT_FILENAME"


### PR DESCRIPTION
Small tweaks in the recipes:

- meteor is now able to use either meteor_demod or meteor-demod (whichever is available in the system)
- recipes now refuse to start if not given 3 parameters
- shellcheck complaints fixed
- updated travis CI (added shellcheck for shell scripts, so far only recipes are tested, more to come)
