### PR TITLE
Improve TLE data presentation

### DIFF
--- a/server/app/static/aquarius.css
+++ b/server/app/static/aquarius.css
@@ -1,0 +1,19 @@
+.tle {
+    display: block;
+    padding: 9.5px;
+    margin: 0 0 10px;
+    font-size: 13px;
+    line-height: 1.42857143;
+    word-break: break-all;
+    word-wrap: break-word;
+    background-color: #f5f5f5;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.tle1 { white-space: pre; color: green }
+.tle2 { white-space: pre; color: black }
+.tle3 { white-space: pre; color: red }
+.tle4 { white-space: pre; color: blue }
+.tle5 { white-space: pre; color: darkorange }
+.tle6 { white-space: pre; color: gray }

--- a/server/app/static/aquarius.css
+++ b/server/app/static/aquarius.css
@@ -1,15 +1,13 @@
-.tle {
-    display: block;
-    padding: 9.5px;
-    margin: 0 0 10px;
-    font-size: 13px;
-    line-height: 1.42857143;
-    word-break: break-all;
-    word-wrap: break-word;
-    background-color: #f5f5f5;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    width: 46em;
+.tle-title {
+    font-weight: bold;
+}
+
+.tle-wrapper {
+    white-space: normal;
+}
+
+.tle-wrapper code {
+    white-space: nowrap;
 }
 
 .tle1 { white-space: pre; color: green }

--- a/server/app/static/aquarius.css
+++ b/server/app/static/aquarius.css
@@ -9,6 +9,7 @@
     background-color: #f5f5f5;
     border: 1px solid #ccc;
     border-radius: 4px;
+    width: 46em;
 }
 
 .tle1 { white-space: pre; color: green }

--- a/server/app/static/bootstrap-custom.css
+++ b/server/app/static/bootstrap-custom.css
@@ -13,3 +13,10 @@
 .text-warning {
     color: orange
 }
+
+.tle { white-space: pre}
+
+.tle1 span { white-space: pre; color: green }
+.tle2 span { white-space: pre; color: blue }
+.tle3 span { white-space: pre; color: black }
+.tle4 span { white-space: pre; color: orange }

--- a/server/app/static/bootstrap-custom.css
+++ b/server/app/static/bootstrap-custom.css
@@ -13,10 +13,3 @@
 .text-warning {
     color: orange
 }
-
-.tle { white-space: pre}
-
-.tle1 span { white-space: pre; color: green }
-.tle2 span { white-space: pre; color: blue }
-.tle3 span { white-space: pre; color: black }
-.tle4 span { white-space: pre; color: orange }

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -6,10 +6,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" />
-  <link rel="stylesheet" href="/static/bootstrap-custom.css" />
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
   <link rel="shortcut icon" href="/static/favicon.png" />
+  <link rel="stylesheet" href="/static/bootstrap-custom.css" />
+  <link rel="stylesheet" href="/static/aquarius.css" />
 
   <script>
     $(document).ready(function(){

--- a/server/templates/obs.html
+++ b/server/templates/obs.html
@@ -23,44 +23,49 @@
     <h4>Pass plots</h4>
 
     <img width="45%" class="tle-plot" alt="Azimuth/elevation by time" src="/data/charts/by_time-{{ obs.obs_id }}.png" />
-    <img width="45%" class="tle-plot" alt="Azimuth/elevation polar" src="/data/charts/polar-{{ obs.obs_id }}.png" /><br/>
+    <img width="45%" class="tle-plot" alt="Azimuth/elevation polar" src="/data/charts/polar-{{ obs.obs_id }}.png" />
 
     <hr/>
 
-    <b>Orbital parameters in <abbr title="Two Line Element, a popular notation that describes Earth orbits">TLE</abbr>:</b><br/>
-    <code class="tle">
-        <!-- TLE LINE 1 -->
-        <abbr title="Line number [column 1]" class="tle1">{{ obs.tle[0][0] }}</abbr>
-        <abbr title="Norad ID [columns 3-7]" class="tle2">{{ obs.tle[0][2:7] }}</abbr><abbr
-              title="Classification: U=unclassified, C=classified S=secret [column 8]" class="tle3">{{ obs.tle[0][7] }}</abbr>
-        <abbr title="Launch year, last two digit [columns 10-11]" class="tle4">{{ obs.tle[0][9:11] }}</abbr><abbr
-              title="launch number of the year [columns 12-14]" class="tle5">{{ obs.tle[0][11:14] }}</abbr><abbr
-              title="piece of the launch, starting with A [columns 15-17]" class="tle1">{{ obs.tle[0][14:17] }}</abbr>
-        <abbr title="Epoch: year, last two digits of a year [columns 19-20]" class="tle2">{{ obs.tle[0][18:20] }}</abbr><abbr
-              title="Epoch: day of the year and fractional portion of the day [columns 21-32]" class="tle3">{{ obs.tle[0][20:32] }}</abbr>
-        <abbr title="First derivative of Mean Motion, aka Ballistic Coefficient [columns 34-43]" class="tle4">{{ obs.tle[0][33:43] }}</abbr>
-        <abbr title="Second derivative of Mean Motion, decimal point assumed [columns 45-52]" class="tle5">{{ obs.tle[0][44:52] }}</abbr>
-        <abbr title="Drag term, Radiation Pressure coefficient or BSTAR, decimal point assumed (i.e. add leading 0.) [columns 54-61]" class="tle1"
-        >{{ obs.tle[0][53:61] }}</abbr>
-        <abbr title="Ephemeris type (internal use only, always zero in distributed TLE data) [column 63]" class="tle2"
-        >{{ obs.tle[0][62] }}</abbr>
-        <abbr title="Element set number, incremented when a new TLE is generated for this object [column 65-68]" class="tle3"
-        >{{ obs.tle[0][64:68] }}</abbr><abbr
-              title="Checksum modulo 10 [column 69]" class="tle6">{{ obs.tle[0][68] }}</abbr>
+    <span class="tle-title">
+        Orbital parameters in 
+        <abbr title="Two Line Element, a popular notation that describes Earth orbits">TLE</abbr>:
+    </span>
+    <pre class="tle-wrapper">
+        <code>
+            <!-- TLE LINE 1 -->
+            <abbr title="Line number [column 1]" class="tle1">{{ obs.tle[0][0] }}</abbr>
+            <abbr title="Norad ID [columns 3-7]" class="tle2">{{ obs.tle[0][2:7] }}</abbr><abbr
+                title="Classification: U=unclassified, C=classified S=secret [column 8]" class="tle3">{{ obs.tle[0][7] }}</abbr>
+            <abbr title="Launch year, last two digit [columns 10-11]" class="tle4">{{ obs.tle[0][9:11] }}</abbr><abbr
+                title="launch number of the year [columns 12-14]" class="tle5">{{ obs.tle[0][11:14] }}</abbr><abbr
+                title="piece of the launch, starting with A [columns 15-17]" class="tle1">{{ obs.tle[0][14:17] }}</abbr>
+            <abbr title="Epoch: year, last two digits of a year [columns 19-20]" class="tle2">{{ obs.tle[0][18:20] }}</abbr><abbr
+                title="Epoch: day of the year and fractional portion of the day [columns 21-32]" class="tle3">{{ obs.tle[0][20:32] }}</abbr>
+            <abbr title="First derivative of Mean Motion, aka Ballistic Coefficient [columns 34-43]" class="tle4">{{ obs.tle[0][33:43] }}</abbr>
+            <abbr title="Second derivative of Mean Motion, decimal point assumed [columns 45-52]" class="tle5">{{ obs.tle[0][44:52] }}</abbr>
+            <abbr title="Drag term, Radiation Pressure coefficient or BSTAR, decimal point assumed (i.e. add leading 0.) [columns 54-61]" class="tle1"
+            >{{ obs.tle[0][53:61] }}</abbr>
+            <abbr title="Ephemeris type (internal use only, always zero in distributed TLE data) [column 63]" class="tle2"
+            >{{ obs.tle[0][62] }}</abbr>
+            <abbr title="Element set number, incremented when a new TLE is generated for this object [column 65-68]" class="tle3"
+            >{{ obs.tle[0][64:68] }}</abbr><abbr
+                title="Checksum modulo 10 [column 69]" class="tle6">{{ obs.tle[0][68] }}</abbr>
 
-        <br/> <!-- TLE LINE 2 -->
+            <br/> <!-- TLE LINE 2 -->
 
-        <abbr title="Line number [column 1]" class="tle1">{{ obs.tle[1][0] }}</abbr>
-        <abbr title="Norad ID [columns 3-7]" class="tle2">{{ obs.tle[1][2:7] }}</abbr>
-        <abbr title="Inclination (degrees) [columns 9-16]" class="tle3">{{ obs.tle[1][8:16] }}</abbr>
-        <abbr title="Right Ascension (longitude) of the Ascending Node (degrees) [columns 18-25]" class="tle4">{{ obs.tle[1][17:25] }}</abbr>
-        <abbr title="Eccentricity with decimal point not assumed, i.e. add leading 0. [columns 27-33]" class="tle5">{{ obs.tle[1][26:33] }}</abbr>
-        <abbr title="Argument of Periapsis (degrees) [columns 35-42]" class="tle1">{{ obs.tle[1][34:42] }}</abbr>
-        <abbr title="Mean anomaly (degrees) [columns 44-51]" class="tle2">{{ obs.tle[1][43:51] }}</abbr>
-        <abbr title="Mean Motion (revolutions per day) [columns 53-63]" class="tle3">{{ obs.tle[1][52:63] }}</abbr><abbr
-              title="Revolution number at epoch (revolutions) [columns 64-68]" class="tle4">{{ obs.tle[1][63:68] }}</abbr><abbr
-              title="Checksum (modulo 10) [column 69]" class="tle6">{{ obs.tle[1][68] }}</abbr>
-    </code>
+            <abbr title="Line number [column 1]" class="tle1">{{ obs.tle[1][0] }}</abbr>
+            <abbr title="Norad ID [columns 3-7]" class="tle2">{{ obs.tle[1][2:7] }}</abbr>
+            <abbr title="Inclination (degrees) [columns 9-16]" class="tle3">{{ obs.tle[1][8:16] }}</abbr>
+            <abbr title="Right Ascension (longitude) of the Ascending Node (degrees) [columns 18-25]" class="tle4">{{ obs.tle[1][17:25] }}</abbr>
+            <abbr title="Eccentricity with decimal point not assumed, i.e. add leading 0. [columns 27-33]" class="tle5">{{ obs.tle[1][26:33] }}</abbr>
+            <abbr title="Argument of Periapsis (degrees) [columns 35-42]" class="tle1">{{ obs.tle[1][34:42] }}</abbr>
+            <abbr title="Mean anomaly (degrees) [columns 44-51]" class="tle2">{{ obs.tle[1][43:51] }}</abbr>
+            <abbr title="Mean Motion (revolutions per day) [columns 53-63]" class="tle3">{{ obs.tle[1][52:63] }}</abbr><abbr
+                title="Revolution number at epoch (revolutions) [columns 64-68]" class="tle4">{{ obs.tle[1][63:68] }}</abbr><abbr
+                title="Checksum (modulo 10) [column 69]" class="tle6">{{ obs.tle[1][68] }}</abbr>
+        </code>
+    </pre>
     {% endif %}
 
     <h4>Attachments:</h4>

--- a/server/templates/obs.html
+++ b/server/templates/obs.html
@@ -24,10 +24,86 @@
 
     <img width="45%" class="tle-plot" alt="Azimuth/elevation by time" src="/data/charts/by_time-{{ obs.obs_id }}.png" />
     <img width="45%" class="tle-plot" alt="Azimuth/elevation polar" src="/data/charts/polar-{{ obs.obs_id }}.png" /><br/>
-    <b>TLE:</b><br/>
-    {{ obs.tle[0] }}<br/>
-    {{ obs.tle[1] }}
+
+    <hr/>
+
+    <!-- playground code -->
+
+    <!-- defining the styles using style directly works fine. -->
+    <code>
+        <span style="color: green; white-space: pre;">01 2  3   4    X</span>
+    </code>
+
+    <!-- defining the styles in .css and then using classes doesn't work. -->
+    <code class="tle1">
+        <span class="tle1">01 2  3   4    X</span>
+    </code>
+
+    <hr/>
+
+    <b>TLE:</b><pre>{{ obs.tle[0] }}
+{{ obs.tle[1] }}</pre>
     {% endif %}
+
+
+    <!-- TLE LINE 1 -->
+    <b>TLE (annotated):</b><br/>
+    <code><abbr title="Line number"><span style="color: green">{{ obs.tle[0][0] }}</span></abbr>
+
+        <abbr title="Norad ID"><span style="color: darkorange">{{ obs.tle[0][2:7] }}</span></abbr>
+
+        <abbr title="Classification: U=unclassified, C=classified S=secret (columns 3-7))"><span style="color: red">{{ obs.tle[0][7] }}</span></abbr>
+
+        <abbr title="Launch year, last two digit (columns 10-11)"><span style="color: blue">{{ obs.tle[0][9:11] }}</span></abbr>
+
+        <abbr title="launch number of the year (columns 12-14)"><span style="color: brown">{{ obs.tle[0][11:14] }}</span></abbr>
+
+        <abbr title="piece of the launch, starting with A (columns 15-17)"><span style="white-space: pre; color:green">{{ obs.tle[0][14:17] }}</span></abbr>
+        <abbr title="Epoch: year, last two digits of a year (columns 19-20)"><span style="color: darkorange">{{ obs.tle[0][18:20] }}</span></abbr>
+        <abbr title="Epoch: day of the year and fractional portion of the day (columns 21-32)"><span style="color: red">{{ obs.tle[0][20:32] }}</span></abbr>
+
+        <abbr title="First derivative of Mean Motion, aka Ballistic Coefficient (columns 34-43)"><span style="color: blue;
+         white-space: pre">{{ obs.tle[0][33:43] }}</span></abbr>
+
+        <abbr title="Second derivative of Mean Motion, decimal point assumed (columns 45-52)"><span style="color: brown;
+        white-space: pre">{{ obs.tle[0][44:52] }}</span></abbr>
+
+        <abbr title="Drag term, Radiation Pressure coefficient or BSTAR (decimal point assumed, columns 54-61)"><span style="color: green;
+        white-space: pre">{{ obs.tle[0][53:61] }}</span></abbr>
+
+        <abbr title="Ephemeris type (internal use only, always zero in distributed TLE data), column 63"><span style="color: darkorange;
+        white-space: pre">{{ obs.tle[0][62] }}</span></abbr>
+
+<abbr title="Element set number, incremented when a new TLE is generated for this object, column 65-68"><span style="color: red;
+    white-space: pre">{{ obs.tle[0][64:68] }}</span></abbr>
+
+<abbr title="Checksum (modulo 10), column 68"><span style="color: gray; white-space: pre">{{ obs.tle[0][68] }}</span></abbr>
+    <br/> <!-- TLE LINE 2 -->
+
+    <abbr title="Line number"><span style="color: green">{{ obs.tle[1][0] }}</span></abbr>
+
+    <abbr title="Norad ID"><span style="color: darkorange">{{ obs.tle[1][2:7] }}</span></abbr>
+
+    <abbr title="Inclination (degrees), columns 9-16"><span style="color: red">{{ obs.tle[1][8:16] }}</span></abbr>
+
+    <abbr title="Right Ascension of the Ascending Node (degrees), columns 18-25"><span style="color: blue">{{ obs.tle[1][17:25]
+    }}</span></abbr>
+
+    <abbr title="Eccentricity (decimal point assumed), columns 27-33"><span style="color: brown">{{ obs.tle[1][26:33]
+    }}</span></abbr>
+
+    <abbr title="Argument of Peryapsis (degrees), columns 35-42"><span style="color: green">{{ obs.tle[1][34:42]
+    }}</span></abbr>
+
+    <abbr title="Mean anomaly (degrees), columns 44-51"><span style="color: darkorange">{{ obs.tle[1][43:51] }}</span></abbr>
+
+    <abbr title="Mean Motion (revolutions per day), columns 53-63"><span style="color: red">{{ obs.tle[1][52:63]
+    }}</span></abbr>
+
+    <abbr title="Revolution number at epoch (revolutions), columns 64-68"><span style="color: blue">{{ obs.tle[1][63:68] }}</span></abbr>
+
+    <abbr title="Checksum (modulo 10), column 69"><span style="color: gray; white-space: pre">{{ obs.tle[0][69] }}</span></abbr>
+</code>
 
     <h4>Attachments:</h4>
     {% for file_ in files %}

--- a/server/templates/obs.html
+++ b/server/templates/obs.html
@@ -27,35 +27,17 @@
 
     <hr/>
 
-    <!-- playground code -->
-
-    <!-- defining the styles using style directly works fine. -->
-    <code>
-        <span style="color: green; white-space: pre;">01 2  3   4    X</span>
-    </code>
-
-    <!-- defining the styles in .css and then using classes doesn't work. -->
-    <code class="tle1">
-        <span class="tle1">01 2  3   4    X</span>
-    </code>
-
-    <hr/>
-
-    <b>TLE:</b><pre>{{ obs.tle[0] }}
-{{ obs.tle[1] }}</pre>
-    {% endif %}
-
-    <b>TLE (annotated):</b><br/>
+    <b>Orbital parameters in <abbr title="Two Line Element, a popular notation that describes Earth orbits">TLE</abbr>:</b><br/>
     <code class="tle">
         <!-- TLE LINE 1 -->
         <abbr title="Line number [column 1]" class="tle1">{{ obs.tle[0][0] }}</abbr>
-        <abbr title="Norad ID [columns 3-7]" class="tle2">{{ obs.tle[0][2:7] }}</abbr>
-        <abbr title="Classification: U=unclassified, C=classified S=secret [column 8]" class="tle3">{{ obs.tle[0][7] }}</abbr>
-        <abbr title="Launch year, last two digit [columns 10-11]" class="tle4">{{ obs.tle[0][9:11] }}</abbr>
-        <abbr title="launch number of the year [columns 12-14]" class="tle5">{{ obs.tle[0][11:14] }}</abbr>
-        <abbr title="piece of the launch, starting with A [columns 15-17]" class="tle1">{{ obs.tle[0][14:17] }}</abbr>
-        <abbr title="Epoch: year, last two digits of a year [columns 19-20]" class="tle2">{{ obs.tle[0][18:20] }}</abbr>
-        <abbr title="Epoch: day of the year and fractional portion of the day [columns 21-32]" class="tle3">{{ obs.tle[0][20:32] }}</abbr>
+        <abbr title="Norad ID [columns 3-7]" class="tle2">{{ obs.tle[0][2:7] }}</abbr><abbr
+              title="Classification: U=unclassified, C=classified S=secret [column 8]" class="tle3">{{ obs.tle[0][7] }}</abbr>
+        <abbr title="Launch year, last two digit [columns 10-11]" class="tle4">{{ obs.tle[0][9:11] }}</abbr><abbr
+              title="launch number of the year [columns 12-14]" class="tle5">{{ obs.tle[0][11:14] }}</abbr><abbr
+              title="piece of the launch, starting with A [columns 15-17]" class="tle1">{{ obs.tle[0][14:17] }}</abbr>
+        <abbr title="Epoch: year, last two digits of a year [columns 19-20]" class="tle2">{{ obs.tle[0][18:20] }}</abbr><abbr
+              title="Epoch: day of the year and fractional portion of the day [columns 21-32]" class="tle3">{{ obs.tle[0][20:32] }}</abbr>
         <abbr title="First derivative of Mean Motion, aka Ballistic Coefficient [columns 34-43]" class="tle4">{{ obs.tle[0][33:43] }}</abbr>
         <abbr title="Second derivative of Mean Motion, decimal point assumed [columns 45-52]" class="tle5">{{ obs.tle[0][44:52] }}</abbr>
         <abbr title="Drag term, Radiation Pressure coefficient or BSTAR, decimal point assumed (i.e. add leading 0.) [columns 54-61]" class="tle1"
@@ -63,8 +45,8 @@
         <abbr title="Ephemeris type (internal use only, always zero in distributed TLE data) [column 63]" class="tle2"
         >{{ obs.tle[0][62] }}</abbr>
         <abbr title="Element set number, incremented when a new TLE is generated for this object [column 65-68]" class="tle3"
-        >{{ obs.tle[0][64:68] }}</abbr>
-        <abbr title="Checksum modulo 10 [column 69]" class="tle6">{{ obs.tle[0][68] }}</abbr>
+        >{{ obs.tle[0][64:68] }}</abbr><abbr
+              title="Checksum modulo 10 [column 69]" class="tle6">{{ obs.tle[0][68] }}</abbr>
 
         <br/> <!-- TLE LINE 2 -->
 
@@ -75,10 +57,11 @@
         <abbr title="Eccentricity with decimal point not assumed, i.e. add leading 0. [columns 27-33]" class="tle5">{{ obs.tle[1][26:33] }}</abbr>
         <abbr title="Argument of Periapsis (degrees) [columns 35-42]" class="tle1">{{ obs.tle[1][34:42] }}</abbr>
         <abbr title="Mean anomaly (degrees) [columns 44-51]" class="tle2">{{ obs.tle[1][43:51] }}</abbr>
-        <abbr title="Mean Motion (revolutions per day) [columns 53-63]" class="tle3">{{ obs.tle[1][52:63] }}</abbr>
-        <abbr title="Revolution number at epoch (revolutions) [columns 64-68]" class="tle4">{{ obs.tle[1][63:68] }}</abbr>
-        <abbr title="Checksum (modulo 10) [column 69]" class="tle6">{{ obs.tle[1][68] }}</abbr>
+        <abbr title="Mean Motion (revolutions per day) [columns 53-63]" class="tle3">{{ obs.tle[1][52:63] }}</abbr><abbr
+              title="Revolution number at epoch (revolutions) [columns 64-68]" class="tle4">{{ obs.tle[1][63:68] }}</abbr><abbr
+              title="Checksum (modulo 10) [column 69]" class="tle6">{{ obs.tle[1][68] }}</abbr>
     </code>
+    {% endif %}
 
     <h4>Attachments:</h4>
     {% for file_ in files %}

--- a/server/templates/obs.html
+++ b/server/templates/obs.html
@@ -45,65 +45,40 @@
 {{ obs.tle[1] }}</pre>
     {% endif %}
 
-
-    <!-- TLE LINE 1 -->
     <b>TLE (annotated):</b><br/>
-    <code><abbr title="Line number"><span style="color: green">{{ obs.tle[0][0] }}</span></abbr>
+    <code class="tle">
+        <!-- TLE LINE 1 -->
+        <abbr title="Line number [column 1]" class="tle1">{{ obs.tle[0][0] }}</abbr>
+        <abbr title="Norad ID [columns 3-7]" class="tle2">{{ obs.tle[0][2:7] }}</abbr>
+        <abbr title="Classification: U=unclassified, C=classified S=secret [column 8]" class="tle3">{{ obs.tle[0][7] }}</abbr>
+        <abbr title="Launch year, last two digit [columns 10-11]" class="tle4">{{ obs.tle[0][9:11] }}</abbr>
+        <abbr title="launch number of the year [columns 12-14]" class="tle5">{{ obs.tle[0][11:14] }}</abbr>
+        <abbr title="piece of the launch, starting with A [columns 15-17]" class="tle1">{{ obs.tle[0][14:17] }}</abbr>
+        <abbr title="Epoch: year, last two digits of a year [columns 19-20]" class="tle2">{{ obs.tle[0][18:20] }}</abbr>
+        <abbr title="Epoch: day of the year and fractional portion of the day [columns 21-32]" class="tle3">{{ obs.tle[0][20:32] }}</abbr>
+        <abbr title="First derivative of Mean Motion, aka Ballistic Coefficient [columns 34-43]" class="tle4">{{ obs.tle[0][33:43] }}</abbr>
+        <abbr title="Second derivative of Mean Motion, decimal point assumed [columns 45-52]" class="tle5">{{ obs.tle[0][44:52] }}</abbr>
+        <abbr title="Drag term, Radiation Pressure coefficient or BSTAR, decimal point assumed (i.e. add leading 0.) [columns 54-61]" class="tle1"
+        >{{ obs.tle[0][53:61] }}</abbr>
+        <abbr title="Ephemeris type (internal use only, always zero in distributed TLE data) [column 63]" class="tle2"
+        >{{ obs.tle[0][62] }}</abbr>
+        <abbr title="Element set number, incremented when a new TLE is generated for this object [column 65-68]" class="tle3"
+        >{{ obs.tle[0][64:68] }}</abbr>
+        <abbr title="Checksum modulo 10 [column 69]" class="tle6">{{ obs.tle[0][68] }}</abbr>
 
-        <abbr title="Norad ID"><span style="color: darkorange">{{ obs.tle[0][2:7] }}</span></abbr>
+        <br/> <!-- TLE LINE 2 -->
 
-        <abbr title="Classification: U=unclassified, C=classified S=secret (columns 3-7))"><span style="color: red">{{ obs.tle[0][7] }}</span></abbr>
-
-        <abbr title="Launch year, last two digit (columns 10-11)"><span style="color: blue">{{ obs.tle[0][9:11] }}</span></abbr>
-
-        <abbr title="launch number of the year (columns 12-14)"><span style="color: brown">{{ obs.tle[0][11:14] }}</span></abbr>
-
-        <abbr title="piece of the launch, starting with A (columns 15-17)"><span style="white-space: pre; color:green">{{ obs.tle[0][14:17] }}</span></abbr>
-        <abbr title="Epoch: year, last two digits of a year (columns 19-20)"><span style="color: darkorange">{{ obs.tle[0][18:20] }}</span></abbr>
-        <abbr title="Epoch: day of the year and fractional portion of the day (columns 21-32)"><span style="color: red">{{ obs.tle[0][20:32] }}</span></abbr>
-
-        <abbr title="First derivative of Mean Motion, aka Ballistic Coefficient (columns 34-43)"><span style="color: blue;
-         white-space: pre">{{ obs.tle[0][33:43] }}</span></abbr>
-
-        <abbr title="Second derivative of Mean Motion, decimal point assumed (columns 45-52)"><span style="color: brown;
-        white-space: pre">{{ obs.tle[0][44:52] }}</span></abbr>
-
-        <abbr title="Drag term, Radiation Pressure coefficient or BSTAR (decimal point assumed, columns 54-61)"><span style="color: green;
-        white-space: pre">{{ obs.tle[0][53:61] }}</span></abbr>
-
-        <abbr title="Ephemeris type (internal use only, always zero in distributed TLE data), column 63"><span style="color: darkorange;
-        white-space: pre">{{ obs.tle[0][62] }}</span></abbr>
-
-<abbr title="Element set number, incremented when a new TLE is generated for this object, column 65-68"><span style="color: red;
-    white-space: pre">{{ obs.tle[0][64:68] }}</span></abbr>
-
-<abbr title="Checksum (modulo 10), column 68"><span style="color: gray; white-space: pre">{{ obs.tle[0][68] }}</span></abbr>
-    <br/> <!-- TLE LINE 2 -->
-
-    <abbr title="Line number"><span style="color: green">{{ obs.tle[1][0] }}</span></abbr>
-
-    <abbr title="Norad ID"><span style="color: darkorange">{{ obs.tle[1][2:7] }}</span></abbr>
-
-    <abbr title="Inclination (degrees), columns 9-16"><span style="color: red">{{ obs.tle[1][8:16] }}</span></abbr>
-
-    <abbr title="Right Ascension of the Ascending Node (degrees), columns 18-25"><span style="color: blue">{{ obs.tle[1][17:25]
-    }}</span></abbr>
-
-    <abbr title="Eccentricity (decimal point assumed), columns 27-33"><span style="color: brown">{{ obs.tle[1][26:33]
-    }}</span></abbr>
-
-    <abbr title="Argument of Peryapsis (degrees), columns 35-42"><span style="color: green">{{ obs.tle[1][34:42]
-    }}</span></abbr>
-
-    <abbr title="Mean anomaly (degrees), columns 44-51"><span style="color: darkorange">{{ obs.tle[1][43:51] }}</span></abbr>
-
-    <abbr title="Mean Motion (revolutions per day), columns 53-63"><span style="color: red">{{ obs.tle[1][52:63]
-    }}</span></abbr>
-
-    <abbr title="Revolution number at epoch (revolutions), columns 64-68"><span style="color: blue">{{ obs.tle[1][63:68] }}</span></abbr>
-
-    <abbr title="Checksum (modulo 10), column 69"><span style="color: gray; white-space: pre">{{ obs.tle[0][69] }}</span></abbr>
-</code>
+        <abbr title="Line number [column 1]" class="tle1">{{ obs.tle[1][0] }}</abbr>
+        <abbr title="Norad ID [columns 3-7]" class="tle2">{{ obs.tle[1][2:7] }}</abbr>
+        <abbr title="Inclination (degrees) [columns 9-16]" class="tle3">{{ obs.tle[1][8:16] }}</abbr>
+        <abbr title="Right Ascension (longitude) of the Ascending Node (degrees) [columns 18-25]" class="tle4">{{ obs.tle[1][17:25] }}</abbr>
+        <abbr title="Eccentricity with decimal point not assumed, i.e. add leading 0. [columns 27-33]" class="tle5">{{ obs.tle[1][26:33] }}</abbr>
+        <abbr title="Argument of Periapsis (degrees) [columns 35-42]" class="tle1">{{ obs.tle[1][34:42] }}</abbr>
+        <abbr title="Mean anomaly (degrees) [columns 44-51]" class="tle2">{{ obs.tle[1][43:51] }}</abbr>
+        <abbr title="Mean Motion (revolutions per day) [columns 53-63]" class="tle3">{{ obs.tle[1][52:63] }}</abbr>
+        <abbr title="Revolution number at epoch (revolutions) [columns 64-68]" class="tle4">{{ obs.tle[1][63:68] }}</abbr>
+        <abbr title="Checksum (modulo 10) [column 69]" class="tle6">{{ obs.tle[1][68] }}</abbr>
+    </code>
 
     <h4>Attachments:</h4>
     {% for file_ in files %}

--- a/server/tests/test_satnogs.py
+++ b/server/tests/test_satnogs.py
@@ -39,12 +39,12 @@ class BasicTests(unittest.TestCase):
         app.config['WTF_CSRF_ENABLED'] = False
         app.config['DEBUG'] = False
         app.config["database"] = self.postgres.dsn()
-        app.config["storage"] = dict()
+        app.config["storage"] = {}
         app.config["storage"]["image_root"] = IMAGE_ROOT
         os.makedirs(os.path.join(IMAGE_ROOT, "thumbs"), exist_ok=True)
         os.makedirs(os.path.join(IMAGE_ROOT, "charts"), exist_ok=True)
 
-        app.config["view"] = dict()
+        app.config["view"] = {}
         app.config["view"]["items_per_page"] = 100
 
         self.app = app.test_client()

--- a/server/tests/test_satnogs.py
+++ b/server/tests/test_satnogs.py
@@ -39,9 +39,14 @@ class BasicTests(unittest.TestCase):
         app.config['WTF_CSRF_ENABLED'] = False
         app.config['DEBUG'] = False
         app.config["database"] = self.postgres.dsn()
+        app.config["storage"] = dict()
         app.config["storage"]["image_root"] = IMAGE_ROOT
         os.makedirs(os.path.join(IMAGE_ROOT, "thumbs"), exist_ok=True)
         os.makedirs(os.path.join(IMAGE_ROOT, "charts"), exist_ok=True)
+
+        app.config["view"] = dict()
+        app.config["view"]["items_per_page"] = 100
+
         self.app = app.test_client()
 
         # This is a test. Log EVERYTHING.


### PR DESCRIPTION
Hey, @fivitti, I'm working on better TLE visualization. One thing I'm struggling with is the bootstrap classes. The current TLE presentation is broken. We don't preserve spaces, so if you try to copy and use it, you'll get errors).

Here's what I came up with:

![tle](https://user-images.githubusercontent.com/663576/107126101-3c49cd80-68ae-11eb-931e-16eb8847ef34.png)

The first is a basic `<pre>` tag that shows plain TLE data. That's boring, but at least it lets users copy the data. The second is more interesting, as each element is color-coded differently and you can hover your mouse over it to get an explanation. It's all cool, but I've encountered the problem.

I've tried to define classes in bootstrap-custom.css:
```css
.tle1 span { white-space: pre; color: green }
.tle2 span { white-space: pre; color: blue }
.tle3 span { white-space: pre; color: black }
.tle4 span { white-space: pre; color: orange }
```

and then use it:
```html
<code class="tle1">
    <span class="tle1">01 2  3   4    X</span>
</code>
```
Sadly, it doesn't work. This, however, works fine:
```html
<code>
    <span style="color: green; white-space: pre;">01 2  3   4    X</span>
</code>
```

Any idea why?