### PR TITLE
Orbit details

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - "3.7"
   - "3.8"
-  - "3.9"
 
 env:
   - SHELLCHECK_OPTS=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 
 python:
-  - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 env:
   - SHELLCHECK_OPTS=""

--- a/server/app/controllers/obs.py
+++ b/server/app/controllers/obs.py
@@ -4,6 +4,7 @@ from app import app
 from app.repository import ObservationId, Repository, Observation
 from app.pagination import use_pagination
 from math import floor
+from app.utils import strfdelta
 
 from tletools import TLE
 
@@ -94,6 +95,6 @@ def human_readable_obs(obs: Observation) -> Observation:
 
 
     obs.aos = obs["aos"].strftime("%Y-%m-%d %H:%M:%S")
-    obs.tca = obs["tca"].strftime("%Y-%m-%d %H:%M:%S") + ", %d min %d secs since AOS" % (tca_duration_m, tca_duration_s) + tca_correction
-    obs.los = obs["los"].strftime("%Y-%m-%d %H:%M:%S") + ", %d min %d secs since AOS" % (los_duration_m, los_duration_s)
+    obs.tca = obs["tca"].strftime("%Y-%m-%d %H:%M:%S") + ", " + strfdelta(aos_tca_duration, fmt="{M:02}m {S:02}s since AOS")
+    obs.los = obs["los"].strftime("%Y-%m-%d %H:%M:%S") + ", " + strfdelta(aos_los_duration, fmt="{M:02}m {S:02}s since AOS")
     return obs

--- a/server/app/controllers/obs.py
+++ b/server/app/controllers/obs.py
@@ -73,10 +73,8 @@ def parse_tle(tle1: str, tle2: str, name: str) -> dict:
     orb["raan"] = "%4.1f %s" % (o.raan.value, o.raan.unit)
     orb["period"] = "%4.0f %s (%dm %ds)" % (o.period.value, o.period.unit, m, s)
 
-    # This is ugly hack. But it converts the ISO 8601 notation to a more human readable form.
-    tmp = str(o.epoch)[:19]
-    tmp = tmp[0:10] + " " + tmp[11:19] # replace T representing the timezone
-    orb["epoch"] = tmp + " UTC" # we don't need nanoseconds precision
+    # Let's convert epoch to something more pleasantly readable.
+    orb["epoch"] = o.epoch.strftime("%Y-%m-%d %H:%M:%S") + " UTC"
 
     return orb
 

--- a/server/app/controllers/obs.py
+++ b/server/app/controllers/obs.py
@@ -4,6 +4,8 @@ from app import app
 from app.repository import ObservationId, Repository
 from app.pagination import use_pagination
 
+from tletools import TLE
+
 @app.route('/obs/<obs_id>')
 @use_pagination(5)
 def obs(obs_id: ObservationId = None, limit_and_offset = None):
@@ -15,13 +17,23 @@ def obs(obs_id: ObservationId = None, limit_and_offset = None):
     with repository.transaction():
         observation = repository.read_observation(obs_id)
 
+        orbit = None
+
         if observation is None:
             abort(404, "Observation not found")
-    
+
+        orbit = observation
+        if observation['tle'] is not None:
+            orbit = parse_tle(observation['tle'][0], observation['tle'][1])
+
         files = repository.read_observation_files(observation["obs_id"],
             **limit_and_offset)
         files_count = repository.count_observation_files(obs_id)
         satellite = repository.read_satellite(observation["sat_id"])
 
     return 'obs.html', dict(obs = observation, files=files,
-        sat_name=satellite["sat_name"], item_count=files_count)
+        sat_name=satellite["sat_name"], item_count=files_count, orbit=orbit)
+
+def parse_tle(tle1, tle2):
+    t = TLE.from_lines(line1=tle1, line2=tle2, name="whatevah")
+    return t.to_orbit()

--- a/server/app/static/aquarius.css
+++ b/server/app/static/aquarius.css
@@ -60,8 +60,18 @@ dd {
     padding: 0 0 0.5em 1em;
 }
 
-.badge {
+.param {
+    display: inline-block;
+    min-width: 10px;
+    padding: 3px 7px;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1;
+    color: #fff;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
     background-color: lightgreen;
     color: black;
-
+    border-radius: 5px;
 }

--- a/server/app/static/aquarius.css
+++ b/server/app/static/aquarius.css
@@ -40,3 +40,27 @@
     border-radius: 5px;
     background-color: white;
 }
+
+dl {
+    padding: 0.5em;
+}
+
+dt {
+    float: left;
+    clear: left;
+    width: 130px;
+    margin: 0 0 0 10px;
+    border: 1px solid black;
+    text-align: right;
+    font-weight: bold;
+}
+
+dd {
+    margin: 0 0 0 50px;
+    padding: 0 0 0.5em 1em;
+}
+
+.badge {
+    background-color: green;
+
+}

--- a/server/app/static/aquarius.css
+++ b/server/app/static/aquarius.css
@@ -49,8 +49,8 @@ dt {
     float: left;
     clear: left;
     width: 130px;
-    margin: 0 0 0 10px;
-    border: 1px solid black;
+    margin: 0 10px 0 0;
+    border: 1px solid green;
     text-align: right;
     font-weight: bold;
 }
@@ -61,6 +61,7 @@ dd {
 }
 
 .badge {
-    background-color: green;
+    background-color: lightgreen;
+    color: black;
 
 }

--- a/server/app/static/bootstrap-custom.css
+++ b/server/app/static/bootstrap-custom.css
@@ -13,3 +13,4 @@
 .text-warning {
     color: orange
 }
+

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -4,7 +4,8 @@ from io import BytesIO
 from os import path
 import shutil
 from typing import Callable, Iterable, Optional, TypeVar
-
+from string import Formatter
+from datetime import timedelta
 
 def coords(lon, lat):
     t = "%2.4f" % lat
@@ -55,3 +56,52 @@ def save_binary_stream_to_file(path: str, stream: BytesIO):
     stream.seek(0)
     with open(path, 'wb') as f:
         shutil.copyfileobj(stream, f, length=131072)
+
+def strfdelta(tdelta, fmt='{D:02}d {H:02}h {M:02}m {S:02}s', inputtype='timedelta'):
+    """Convert a datetime.timedelta object or a regular number to a custom-
+    formatted string, just like the stftime() method does for datetime.datetime
+    objects.
+
+    The fmt argument allows custom formatting to be specified.  Fields can
+    include seconds, minutes, hours, days, and weeks.  Each field is optional.
+
+    Some examples:
+        '{D:02}d {H:02}h {M:02}m {S:02}s' --> '05d 08h 04m 02s' (default)
+        '{W}w {D}d {H}:{M:02}:{S:02}'     --> '4w 5d 8:04:02'
+        '{D:2}d {H:2}:{M:02}:{S:02}'      --> ' 5d  8:04:02'
+        '{H}h {S}s'                       --> '72h 800s'
+
+    The inputtype argument allows tdelta to be a regular number instead of the
+    default, which is a datetime.timedelta object.  Valid inputtype strings:
+        's', 'seconds',
+        'm', 'minutes',
+        'h', 'hours',
+        'd', 'days',
+        'w', 'weeks'
+
+    by MarredCheese, source: https://stackoverflow.com/questions/538666/
+    """
+
+    # Convert tdelta to integer seconds.
+    if inputtype == 'timedelta':
+        remainder = int(tdelta.total_seconds())
+    elif inputtype in ['s', 'seconds']:
+        remainder = int(tdelta)
+    elif inputtype in ['m', 'minutes']:
+        remainder = int(tdelta)*60
+    elif inputtype in ['h', 'hours']:
+        remainder = int(tdelta)*3600
+    elif inputtype in ['d', 'days']:
+        remainder = int(tdelta)*86400
+    elif inputtype in ['w', 'weeks']:
+        remainder = int(tdelta)*604800
+
+    f = Formatter()
+    desired_fields = [field_tuple[1] for field_tuple in f.parse(fmt)]
+    possible_fields = ('W', 'D', 'H', 'M', 'S')
+    constants = {'W': 604800, 'D': 86400, 'H': 3600, 'M': 60, 'S': 1}
+    values = {}
+    for field in possible_fields:
+        if field in desired_fields and field in constants:
+            values[field], remainder = divmod(remainder, constants[field])
+    return f.format(fmt, **values)

--- a/server/requirements.in
+++ b/server/requirements.in
@@ -9,3 +9,4 @@ python-crontab
 testing.postgresql
 orbit-predictor
 matplotlib
+tle-tools

--- a/server/requirements.in
+++ b/server/requirements.in
@@ -1,7 +1,7 @@
 Flask
 flask_wtf
 flask_login
-psycopg2
+psycopg2-binary
 webargs
 typing_extensions
 python-dateutil

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,35 +4,79 @@
 #
 #    pip-compile requirements.in
 #
-certifi==2020.4.5         # via requests
-chardet==3.0.4            # via requests
-click==7.0                # via flask
-cycler==0.10.0            # via matplotlib
-flask-login==0.5.0        # via -r requirements.in
-flask-wtf==0.14.3         # via -r requirements.in
-flask==1.1.1              # via -r requirements.in, flask-login, flask-wtf
-idna==2.9                 # via requests
-itsdangerous==1.1.0       # via flask, flask-wtf
-jinja2==2.11.1            # via flask
-kiwisolver==1.2.0         # via matplotlib
-markupsafe==1.1.1         # via jinja2
-marshmallow==3.5.0        # via webargs
-matplotlib==3.2.1         # via -r requirements.in
-numpy==1.18.2             # via matplotlib, orbit-predictor
-orbit-predictor==1.12.0   # via -r requirements.in
-pg8000==1.14.1            # via testing.postgresql
-psycopg2==2.8.4           # via -r requirements.in
-pyparsing==2.4.6          # via matplotlib
-python-crontab==2.4.1     # via -r requirements.in
-python-dateutil==2.8.1    # via -r requirements.in, matplotlib, python-crontab
-requests==2.23.0          # via orbit-predictor
-scramp==1.1.0             # via pg8000
-sgp4==2.5                 # via orbit-predictor
-six==1.14.0               # via cycler, python-dateutil
-testing.common.database==2.0.3  # via testing.postgresql
-testing.postgresql==1.3.0  # via -r requirements.in
-typing-extensions==3.7.4.1  # via -r requirements.in
-urllib3==1.25.8           # via requests
-webargs==5.5.3            # via -r requirements.in
-werkzeug==1.0.0           # via flask
-wtforms==2.2.1            # via flask-wtf
+certifi==2020.4.5
+    # via requests
+chardet==3.0.4
+    # via requests
+click==7.0
+    # via flask
+cycler==0.10.0
+    # via matplotlib
+flask-login==0.5.0
+    # via -r requirements.in
+flask-wtf==0.14.3
+    # via -r requirements.in
+flask==1.1.1
+    # via
+    #   -r requirements.in
+    #   flask-login
+    #   flask-wtf
+idna==2.9
+    # via requests
+itsdangerous==1.1.0
+    # via
+    #   flask
+    #   flask-wtf
+jinja2==2.11.1
+    # via flask
+kiwisolver==1.2.0
+    # via matplotlib
+markupsafe==1.1.1
+    # via jinja2
+marshmallow==3.5.0
+    # via webargs
+matplotlib==3.2.1
+    # via -r requirements.in
+numpy==1.18.2
+    # via
+    #   matplotlib
+    #   orbit-predictor
+orbit-predictor==1.12.0
+    # via -r requirements.in
+pg8000==1.14.1
+    # via testing.postgresql
+psycopg2-binary==2.8.6
+    # via -r requirements.in
+pyparsing==2.4.6
+    # via matplotlib
+python-crontab==2.4.1
+    # via -r requirements.in
+python-dateutil==2.8.1
+    # via
+    #   -r requirements.in
+    #   matplotlib
+    #   python-crontab
+requests==2.23.0
+    # via orbit-predictor
+scramp==1.1.0
+    # via pg8000
+sgp4==2.5
+    # via orbit-predictor
+six==1.14.0
+    # via
+    #   cycler
+    #   python-dateutil
+testing.common.database==2.0.3
+    # via testing.postgresql
+testing.postgresql==1.3.0
+    # via -r requirements.in
+typing-extensions==3.7.4.1
+    # via -r requirements.in
+urllib3==1.25.8
+    # via requests
+webargs==5.5.3
+    # via -r requirements.in
+werkzeug==1.0.0
+    # via flask
+wtforms==2.2.1
+    # via flask-wtf

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,12 +4,27 @@
 #
 #    pip-compile requirements.in
 #
+astropy==4.2
+    # via
+    #   astroquery
+    #   poliastro
+    #   tle-tools
+astroquery==0.4.1
+    # via poliastro
+attrs==20.3.0
+    # via tle-tools
+beautifulsoup4==4.9.3
+    # via astroquery
 certifi==2020.4.5
     # via requests
+cffi==1.14.5
+    # via cryptography
 chardet==3.0.4
     # via requests
 click==7.0
     # via flask
+cryptography==3.4.6
+    # via secretstorage
 cycler==0.10.0
     # via matplotlib
 flask-login==0.5.0
@@ -21,32 +36,69 @@ flask==1.1.1
     #   -r requirements.in
     #   flask-login
     #   flask-wtf
+html5lib==1.1
+    # via astroquery
 idna==2.9
     # via requests
 itsdangerous==1.1.0
     # via
     #   flask
     #   flask-wtf
+jeepney==0.6.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==2.11.1
     # via flask
+jplephem==2.15
+    # via poliastro
+keyring==22.0.1
+    # via astroquery
 kiwisolver==1.2.0
     # via matplotlib
+llvmlite==0.35.0
+    # via numba
 markupsafe==1.1.1
     # via jinja2
 marshmallow==3.5.0
     # via webargs
 matplotlib==3.2.1
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   poliastro
+numba==0.52.0
+    # via poliastro
 numpy==1.18.2
     # via
+    #   astropy
+    #   astroquery
+    #   jplephem
     #   matplotlib
+    #   numba
     #   orbit-predictor
+    #   pandas
+    #   poliastro
+    #   pyerfa
+    #   scipy
+    #   tle-tools
 orbit-predictor==1.12.0
     # via -r requirements.in
+pandas==1.2.2
+    # via
+    #   poliastro
+    #   tle-tools
 pg8000==1.14.1
     # via testing.postgresql
+plotly==4.14.3
+    # via poliastro
+poliastro==0.14.0
+    # via tle-tools
 psycopg2-binary==2.8.6
     # via -r requirements.in
+pycparser==2.20
+    # via cffi
+pyerfa==1.7.2
+    # via astropy
 pyparsing==2.4.6
     # via matplotlib
 python-crontab==2.4.1
@@ -55,20 +107,39 @@ python-dateutil==2.8.1
     # via
     #   -r requirements.in
     #   matplotlib
+    #   pandas
     #   python-crontab
+pytz==2021.1
+    # via pandas
 requests==2.23.0
-    # via orbit-predictor
+    # via
+    #   astroquery
+    #   orbit-predictor
+retrying==1.3.3
+    # via plotly
+scipy==1.6.0
+    # via poliastro
 scramp==1.1.0
     # via pg8000
+secretstorage==3.3.1
+    # via keyring
 sgp4==2.5
     # via orbit-predictor
 six==1.14.0
     # via
+    #   astroquery
     #   cycler
+    #   html5lib
+    #   plotly
     #   python-dateutil
+    #   retrying
+soupsieve==2.2
+    # via beautifulsoup4
 testing.common.database==2.0.3
     # via testing.postgresql
 testing.postgresql==1.3.0
+    # via -r requirements.in
+tle-tools==0.2.3
     # via -r requirements.in
 typing-extensions==3.7.4.1
     # via -r requirements.in
@@ -76,7 +147,12 @@ urllib3==1.25.8
     # via requests
 webargs==5.5.3
     # via -r requirements.in
+webencodings==0.5.1
+    # via html5lib
 werkzeug==1.0.0
     # via flask
 wtforms==2.2.1
     # via flask-wtf
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -56,7 +56,7 @@
     <div class="container">{% block content %}{% endblock %}</div>
     <div id="footer" class="text-center">
         {% block footer %}
-        &copy; Copyright 2020 by AQUARIUS.
+        &copy; Copyright 2021 by AQUARIUS team.
         {% if footer %}
         Version <a href="https://github.com/gut-space/satnogs/commit/{{ footer.commit }}">{{ footer.commit }}</a>,
         updated on {{ footer.timestamp }}

--- a/server/templates/obs.html
+++ b/server/templates/obs.html
@@ -51,7 +51,7 @@
         <dt class="badge">Perigee</dt><dd> {{ orbit.r_p}} </dd>
         <dt class="badge"><abbr title="Right Ascension of the Ascending Node (or longtiude of the AN),
 describes the angle where orbital plane crosses the equatorial plane.
-In other words, how rotated the orbital plane is around the the polar N-S axis.">RAAN &Omega;</abbr>
+In other words, how rotated the orbital plane is around the the polar N-S axis.">RAAN <i>&Omega;</i></abbr>
         </dt><dd> {{orbit.raan}} </dd>
         <dt class="badge">Epoch</dt><dd>{{ orbit.epoch }}</dd>
 
@@ -99,8 +99,8 @@ In other words, how rotated the orbital plane is around the the polar N-S axis."
 
     {% endif %}
 
-    <h4>Attachments:</h4>
-    <p>Full resolution image (click for full res):</p>
+    <h4>Products</h4>
+    <p>Click on images to get full resolution.</p>
     {% for file_ in files %}
         <div class="product-wrapper">
             {% if file_.rating %}

--- a/server/templates/obs.html
+++ b/server/templates/obs.html
@@ -11,9 +11,16 @@
     <h4>Transmission parameters</h4>
     <p>
         <dl>
-            <dt class="badge">AOS</dt><dd>{{ obs.aos }}</dd>
-            <dt class="badge">TCA</dt><dd>{{ obs.tca }}</dd>
-            <dt class="badge">LOS</dt><dd>{{ obs.los }}</dd>
+            <dt class="badge">
+                <abbr title="Acquistion of Signal, when the satellite was first seen over the horizon">AOS</abbr>
+            </dt><dd>{{ obs.aos }}</dd>
+
+            <dt class="badge">
+                <abbr title="Time of Closest Approach, a moment when the satellite was closest to the observer (and typically highest over the horizon">TCA</abbr>
+            </dt>
+            <dd>{{ obs.tca }}</dd>
+
+            <dt class="badge"><abbr title="Loss of Signal, when the satellite set under the horizon and was no longer visible">LOS</abbr></dt><dd>{{ obs.los }}</dd>
             {% if obs.notes %}
             <dt class="badge">Notes</dt><dd>{{ obs.notes }}</dd>
             {% endif %}
@@ -40,9 +47,13 @@
         <dt class="badge">Inclination <i>i</i></dt><dd> {{ orbit.inc }}</dd>
         <dt class="badge">Major semi-axis <i>a</i></dt><dd>{{ "%4.1f %s" % (orbit.a.value, orbit.a.unit) }}</dd>
         <dt class="badge">Eccentricity <i>e</i></dt><dd>{{ orbit.ecc }}</dd>
-        <dt class="badge">Apogee</dt><dd>...</dd>
-        <dt class="badge">Perigee</dt><dd>...</dd>
-        <dt class="badge">RAAN &Omega;</dt><dd>...</dd>
+        <dt class="badge">Apogee</dt><dd> {{ orbit.r_a}} </dd>
+        <dt class="badge">Perigee</dt><dd> {{ orbit.r_p}} </dd>
+        <dt class="badge"><abbr title="Right Ascension of the Ascending Node (or longtiude of the AN),
+describes the angle where orbital plane crosses the equatorial plane.
+In other words, how rotated the orbital plane is around the the polar N-S axis.">RAAN &Omega;</abbr>
+        </dt><dd> {{orbit.raan}} </dd>
+        <dt class="badge">Epoch</dt><dd>{{ orbit.epoch }}</dd>
 
 
     <dt class="badge"><abbr title="Two Line Element, a popular notation that describes Earth orbits">TLE format</abbr></dt>

--- a/server/templates/obs.html
+++ b/server/templates/obs.html
@@ -4,9 +4,9 @@
 {% block content %}
     <h3>Observation  {{ obs.obs_id }}</h3>
 
-    <p style="float: right">
+    <div style="float: right">
         <img src="/data/thumbs/{{ obs.thumbnail }}" />
-    </p>
+    </div>
 
     <h4>Transmission parameters</h4>
     <p>

--- a/server/templates/obs.html
+++ b/server/templates/obs.html
@@ -4,26 +4,27 @@
 {% block content %}
     <h3>Observation  {{ obs.obs_id }}</h3>
 
-    <p>
-        Thumbnail:<br/>
+    <p style="float: right">
         <img src="/data/thumbs/{{ obs.thumbnail }}" />
     </p>
+
+    <h4>Transmission parameters</h4>
     <p>
         <dl>
-            <dt>AOS:</dt><dd>{{ obs.aos }}</dd>
-            <dt>TCA:</dt><dd>{{ obs.tca }}</dd>
-            <dt>LOS:</dt><dd>{{ obs.los }}</dd>
+            <dt class="badge">AOS</dt><dd>{{ obs.aos }}</dd>
+            <dt class="badge">TCA</dt><dd>{{ obs.tca }}</dd>
+            <dt class="badge">LOS</dt><dd>{{ obs.los }}</dd>
             {% if obs.notes %}
-            <dt>Notes:</dt><dd>{{ obs.notes }}</dd>
+            <dt class="badge">Notes</dt><dd>{{ obs.notes }}</dd>
             {% endif %}
             {% if obs.rating %}
-            <dt>Rating:</dt>
+            <dt class="badge">Rating</dt>
             <dd>
                 {{ rating_icon(obs.rating, border=False) }}
             </dd>
             {% endif %}
-            <dt>Satellite:</dt><dd><a href="https://www.n2yo.com/satellite/?s={{ obs.sat_id }}">{{ sat_name }}</a></dd>
-            <dt>Ground station:</dt><dd><a href="/station/{{ obs.station_id }}">Link</a></dd>
+            <dt class="badge">Satellite</dt><dd><a href="https://www.n2yo.com/satellite/?s={{ obs.sat_id }}">{{ sat_name }}</a></dd>
+            <dt class="badge">Ground station</dt><dd><a href="/station/{{ obs.station_id }}">Link</a></dd>
         </dl>
     </p>
     {% if obs.tle %}
@@ -32,12 +33,20 @@
     <img width="45%" class="tle-plot" alt="Azimuth/elevation by time" src="/data/charts/by_time-{{ obs.obs_id }}.png" />
     <img width="45%" class="tle-plot" alt="Azimuth/elevation polar" src="/data/charts/polar-{{ obs.obs_id }}.png" />
 
-    <hr/>
+    <h4>Orbital parameters</h4>
+    <p>
+    <dl>
+        <dt class="badge">Orbit overview</dt><dd>{{ orbit }}</dd>
+        <dt class="badge">Inclination <i>i</i></dt><dd> {{ orbit.inc }}</dd>
+        <dt class="badge">Major semi-axis <i>a</i></dt><dd>{{ "%4.1f %s" % (orbit.a.value, orbit.a.unit) }}</dd>
+        <dt class="badge">Eccentricity <i>e</i></dt><dd>{{ orbit.ecc }}</dd>
+        <dt class="badge">Apogee</dt><dd>...</dd>
+        <dt class="badge">Perigee</dt><dd>...</dd>
+        <dt class="badge">RAAN &Omega;</dt><dd>...</dd>
 
-    <span class="tle-title">
-        Orbital parameters in 
-        <abbr title="Two Line Element, a popular notation that describes Earth orbits">TLE</abbr>:
-    </span>
+
+    <dt class="badge"><abbr title="Two Line Element, a popular notation that describes Earth orbits">TLE format</abbr></dt>
+    <dd>
     <pre class="tle-wrapper">
         <code>
             <!-- TLE LINE 1 -->
@@ -73,6 +82,10 @@
                 title="Checksum (modulo 10) [column 69]" class="tle6">{{ obs.tle[1][68] }}</abbr>
         </code>
     </pre>
+</dd>
+</dl>
+</p>
+
     {% endif %}
 
     <h4>Attachments:</h4>

--- a/server/templates/obs.html
+++ b/server/templates/obs.html
@@ -30,7 +30,8 @@
                 {{ rating_icon(obs.rating, border=False) }}
             </dd>
             {% endif %}
-            <dt class="badge">Satellite</dt><dd><a href="https://www.n2yo.com/satellite/?s={{ obs.sat_id }}">{{ sat_name }}</a></dd>
+            <dt class="badge">Satellite</dt><dd><a href="https://www.n2yo.com/satellite/?s={{ obs.sat_id }}">{{ sat_name }}</a>,
+                norad id {{ obs.sat_id }}</dd>
             <dt class="badge">Ground station</dt><dd><a href="/station/{{ obs.station_id }}">Link</a></dd>
         </dl>
     </p>
@@ -43,7 +44,7 @@
     <h4>Orbital parameters</h4>
     <p>
     <dl>
-        <dt class="badge">Orbit overview</dt><dd>{{ orbit }}</dd>
+        <dt class="badge">Orbit overview</dt><dd>{{ orbit.overview }}</dd>
         <dt class="badge">Inclination <i>i</i></dt><dd> {{ orbit.inc }}</dd>
         <dt class="badge">Major semi-axis <i>a</i></dt><dd>{{ "%4.1f %s" % (orbit.a.value, orbit.a.unit) }}</dd>
         <dt class="badge">Eccentricity <i>e</i></dt><dd>{{ orbit.ecc }}</dd>
@@ -54,6 +55,7 @@ describes the angle where orbital plane crosses the equatorial plane.
 In other words, how rotated the orbital plane is around the the polar N-S axis.">RAAN <i>&Omega;</i></abbr>
         </dt><dd> {{orbit.raan}} </dd>
         <dt class="badge">Epoch</dt><dd>{{ orbit.epoch }}</dd>
+        <dt class="badge">Period</dt><dd>{{ orbit.period }}</dd>
 
 
     <dt class="badge"><abbr title="Two Line Element, a popular notation that describes Earth orbits">TLE format</abbr></dt>

--- a/server/templates/obs.html
+++ b/server/templates/obs.html
@@ -11,28 +11,28 @@
     <h4>Transmission parameters</h4>
     <p>
         <dl>
-            <dt class="badge">
+            <dt class="param">
                 <abbr title="Acquistion of Signal, when the satellite was first seen over the horizon">AOS</abbr>
             </dt><dd>{{ obs.aos }}</dd>
 
-            <dt class="badge">
+            <dt class="param">
                 <abbr title="Time of Closest Approach, a moment when the satellite was closest to the observer (and typically highest over the horizon">TCA</abbr>
             </dt>
             <dd>{{ obs.tca }}</dd>
 
-            <dt class="badge"><abbr title="Loss of Signal, when the satellite set under the horizon and was no longer visible">LOS</abbr></dt><dd>{{ obs.los }}</dd>
+            <dt class="param"><abbr title="Loss of Signal, when the satellite set under the horizon and was no longer visible">LOS</abbr></dt><dd>{{ obs.los }}</dd>
             {% if obs.notes %}
-            <dt class="badge">Notes</dt><dd>{{ obs.notes }}</dd>
+            <dt class="param">Notes</dt><dd>{{ obs.notes }}</dd>
             {% endif %}
             {% if obs.rating %}
-            <dt class="badge">Rating</dt>
+            <dt class="param">Rating</dt>
             <dd>
                 {{ rating_icon(obs.rating, border=False) }}
             </dd>
             {% endif %}
-            <dt class="badge">Satellite</dt><dd><a href="https://www.n2yo.com/satellite/?s={{ obs.sat_id }}">{{ sat_name }}</a>,
+            <dt class="param">Satellite</dt><dd><a href="https://www.n2yo.com/satellite/?s={{ obs.sat_id }}">{{ sat_name }}</a>,
                 norad id {{ obs.sat_id }}</dd>
-            <dt class="badge">Ground station</dt><dd><a href="/station/{{ obs.station_id }}">Link</a></dd>
+            <dt class="param">Ground station</dt><dd><a href="/station/{{ obs.station_id }}">{{station.name}}</a></dd>
         </dl>
     </p>
     {% if obs.tle %}
@@ -44,21 +44,21 @@
     <h4>Orbital parameters</h4>
     <p>
     <dl>
-        <dt class="badge">Orbit overview</dt><dd>{{ orbit.overview }}</dd>
-        <dt class="badge">Inclination <i>i</i></dt><dd> {{ orbit.inc }}</dd>
-        <dt class="badge">Major semi-axis <i>a</i></dt><dd>{{ "%4.1f %s" % (orbit.a.value, orbit.a.unit) }}</dd>
-        <dt class="badge">Eccentricity <i>e</i></dt><dd>{{ orbit.ecc }}</dd>
-        <dt class="badge">Apogee</dt><dd> {{ orbit.r_a}} </dd>
-        <dt class="badge">Perigee</dt><dd> {{ orbit.r_p}} </dd>
-        <dt class="badge"><abbr title="Right Ascension of the Ascending Node (or longtiude of the AN),
+        <dt class="param">Orbit overview</dt><dd>{{ orbit.overview }}</dd>
+        <dt class="param">Inclination <i>i</i></dt><dd> {{ orbit.inc }}</dd>
+        <dt class="param">Major semi-axis <i>a</i></dt><dd>{{ "%4.1f %s" % (orbit.a.value, orbit.a.unit) }}</dd>
+        <dt class="param">Eccentricity <i>e</i></dt><dd>{{ orbit.ecc }}</dd>
+        <dt class="param">Apogee</dt><dd> {{ orbit.r_a}} </dd>
+        <dt class="param">Perigee</dt><dd> {{ orbit.r_p}} </dd>
+        <dt class="param"><abbr title="Right Ascension of the Ascending Node (or longtiude of the AN),
 describes the angle where orbital plane crosses the equatorial plane.
 In other words, how rotated the orbital plane is around the the polar N-S axis.">RAAN <i>&Omega;</i></abbr>
         </dt><dd> {{orbit.raan}} </dd>
-        <dt class="badge">Epoch</dt><dd>{{ orbit.epoch }}</dd>
-        <dt class="badge">Period</dt><dd>{{ orbit.period }}</dd>
+        <dt class="param">Epoch</dt><dd>{{ orbit.epoch }}</dd>
+        <dt class="param">Period</dt><dd>{{ orbit.period }}</dd>
 
 
-    <dt class="badge"><abbr title="Two Line Element, a popular notation that describes Earth orbits">TLE format</abbr></dt>
+    <dt class="param"><abbr title="Two Line Element, a popular notation that describes Earth orbits">TLE format</abbr></dt>
     <dd>
     <pre class="tle-wrapper">
         <code>


### PR DESCRIPTION
This change adds a nice presentation of orbital data, as shown below:

Here's a sneak peek. BEFORE:
![before](https://user-images.githubusercontent.com/663576/108248634-69bb3480-7154-11eb-8ae4-14d726137256.png)

AFTER:
![after](https://user-images.githubusercontent.com/663576/108248647-6e7fe880-7154-11eb-8679-5748e3b665c7.png)

This introduces also several dependencies (tle-tools and poliastro). Some of them are heavy. This is unfortunate, but IMHO the benefits outweigh the problems. First, the poliastro package is a powerful environment for anything orbital mechanics-related, such as plotting ground track, calculating orbital drift (for example we could try to predict changing TLE parameters on our own, rather than rely on Celestrak to provide data), has atmospheric models (we could simulate PW-Sat2 orbital decay for example), has tons of plotting capabilities (including interactive 3D charts) and more. A great way to get a quick feeling of what poliastro is capable of is the [gallery](https://docs.poliastro.space/en/latest/gallery.html).

@fivitti rightfully pointed out that some of the dependencies, such as NumPy or AstroPy, are more oriented at the scientific community, rather than web development. That is certainly true. However, this project is not intended for mass consumers. Personally, I very much hope it will evolve more into a scientific/RF engineering direction.

I have also personal reasons to like poliastro and tle-tools. I've contributed to both and the community and the primary maintainer of both are friendly and a pleasure to work with. I also have developed several code pieces in my master thesis that I can see could be potentially useful here. The code uses poliastro.

Finally, I think it's ok for the dependencies to be heavy as long as they're confined to the server side. I fully agree that those would be too much for the station.